### PR TITLE
Force mouse binding to override user's input.conf

### DIFF
--- a/easycrop.lua
+++ b/easycrop.lua
@@ -233,7 +233,7 @@ local easycrop_start = function ()
     mp.set_property("osc", "no")
 
     cropping = true
-    mp.add_key_binding("mouse_btn0", "easycrop_mouse_btn0", mouse_btn0_cb)
+    mp.add_forced_key_binding("mouse_btn0", "easycrop_mouse_btn0", mouse_btn0_cb)
     draw_fill()
 end
 


### PR DESCRIPTION
This ensures that corners still can be selected even if `MOUSE_BTN0` is assigned in the user's input.conf.

Because of aidanholm@0ee2ece4ce05c1aff2deab6d27f1223fd47f49ed this should not yield any unwanted side effects.