### PR TITLE
Videotoolbox (macOS hwdec) support

### DIFF
--- a/easycrop.lua
+++ b/easycrop.lua
@@ -212,6 +212,7 @@ local easycrop_start = function ()
     local valid_hwdec = {
        ["no"] = true, -- software decoding
        -- Taken from mpv manual
+       ["videotoolbox-co"] = true,
        ["vaapi-copy"] = true,
        ["dxva2-copy"] = true,
        ["d3d11va-copy"] = true,


### PR DESCRIPTION
macOS uses videotoolbox (apple stuff) as it's hardware decoding backend. `videotoolbox-co` works well together with this script. 